### PR TITLE
Fix parallel processing argument

### DIFF
--- a/R/dc.sim.R
+++ b/R/dc.sim.R
@@ -40,6 +40,6 @@ dc.sim = function(nsim = 1, nn, ty, ex, w, pop, max_pop,
             max_pop = max_pop, type = "maxonly",
             early = TRUE, nlinks = "two", progress = FALSE)
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }

--- a/R/dmst.sim.R
+++ b/R/dmst.sim.R
@@ -40,6 +40,6 @@ dmst.sim = function(nsim = 1, nn, ty, ex, w, pop, max_pop,
             max_pop = max_pop, type = "maxonly",
             early = FALSE, nlinks = "one", progress = FALSE)
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }

--- a/R/edmst.sim.R
+++ b/R/edmst.sim.R
@@ -40,6 +40,6 @@ edmst.sim = function(nsim = 1, nn, ty, ex, w, pop, max_pop,
             max_pop = max_pop, type = "maxonly",
             early = TRUE, nlinks = "one", progress = FALSE)
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }

--- a/R/elliptic.sim.R
+++ b/R/elliptic.sim.R
@@ -42,7 +42,7 @@ elliptic.sim = function(nsim = 1, nn, ty, ex, a, shape_all,
     # compute test statistics for each zone
     yin = nn.cumsum(nn, ysim)
     max(stat.poisson(yin, ty - yin, ein, eout, a, shape_all))
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }
 

--- a/R/fast.sim.R
+++ b/R/fast.sim.R
@@ -42,6 +42,6 @@ fast.sim = function(nsim = 1, ty, ex, pop, ubpop,
                         popin, tpop - popin, tpop)
     }
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }

--- a/R/flex.sim.R
+++ b/R/flex.sim.R
@@ -48,7 +48,7 @@ flex.sim = function(nsim = 1, zones, ty, ex, type = "poisson",
                         popin, popout, tpop)
     }
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }
 

--- a/R/mlink.sim.R
+++ b/R/mlink.sim.R
@@ -40,6 +40,6 @@ mlink.sim = function(nsim = 1, nn, ty, ex, w, pop, max_pop,
             max_pop = max_pop, type = "maxonly",
             early = FALSE, nlinks = "max", progress = FALSE)
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }

--- a/R/rflex.sim.R
+++ b/R/rflex.sim.R
@@ -61,6 +61,6 @@ rflex.sim = function(nsim = 1, nn, w, ex, alpha1 = 0.2,
                         popin, tpop - popin, tpop)
     }
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }

--- a/R/scan.sim.R
+++ b/R/scan.sim.R
@@ -63,7 +63,7 @@ scan.sim = function(nsim = 1, nn, ty, ex, type = "poisson",
       tall = stat.binom(yin, ty - yin, ty, popin, popout, tpop)
     }
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }
 

--- a/R/seq_scan_sim.R
+++ b/R/seq_scan_sim.R
@@ -69,7 +69,7 @@ seq_scan_sim = function(nsim = 1, nn, ty, ex, type = "poisson",
     sapply(lseq_zones, function(lzones) {
       max(tall[lzones])
     })
-  })
+  }, cl = cl)
   return(tsim)
 }
 

--- a/R/uls.sim.R
+++ b/R/uls.sim.R
@@ -46,6 +46,6 @@ uls.sim = function(nsim = 1, ty, ex, w, pop, ubpop,
                         popin, tpop - popin, tpop)
     }
     max(tall)
-  })
+  }, cl = cl)
   unlist(tsim, use.names = FALSE)
 }


### PR DESCRIPTION
Hello, I want to ask you to pull my request that explicitly added `cl` parameter in simulation functions (i.e., `*.sim`).
- In most *sim.R files, cl parameter in pbapply::pblapply functions is missing
- Added cl parameter in functions with it

1. Before fix
```{r}
library(smerc)
#> # This research was partially supported under NSF grant 1463642
data(nydf)
coords = with(nydf, cbind(longitude, latitude))

system.time({out = elliptic.test(coords = coords,
                        cases = floor(nydf$cases),
                        pop = nydf$pop, ubpop = 0.25,
                        nsim = 499,
                        alpha = 0.05,
                        shape = 1.5, nangle = 4)})
#>    user  system elapsed 
#>   4.241   0.014   4.255
```

2. After fix
```{r}
library(smerc)
#> # This research was partially supported under NSF grant 1463642
library(parallel)
data(nydf)
coords = with(nydf, cbind(longitude, latitude))
cl = makePSOCKcluster(8)
system.time({out = elliptic.test(coords = coords,
                        cases = floor(nydf$cases),
                        pop = nydf$pop, ubpop = 0.25,
                        nsim = 499,
                        alpha = 0.05,
                        shape = 1.5, nangle = 4, cl = cl)})
#>    user  system elapsed 
#>   0.332   0.029   1.724

```

Thank you very much. I hope my request will be accepted.